### PR TITLE
Extra cookies management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 -- v0.2.2 - delete method added, thanks @pablobfonseca
 -- v0.2.3 - adding parameter params in order to handle in_url parameters
 -- v0.2.4 - adding parametes to post requests
+-- v0.2.5 - adding public method cookie_string

--- a/lib/tweakphoeus/version.rb
+++ b/lib/tweakphoeus/version.rb
@@ -1,3 +1,3 @@
 module Tweakphoeus
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
- Added `cookie_string` public method to get "Cookie" HTTP header.
- Removed obsolete `inject_cookies` method in favor of `cookie_string` functionality